### PR TITLE
Improvements to LWRP and Documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+
+Description
+===========
+
+A Light-weight Resource and Provider (LWRP) supporting
+automatic DNS configuration via DNSimple's API.
+
+Changes
+=======
+
+* Convert README to markdown so it is displayed nice on Community
+  site.
+* Add default action `:create` for `dnsimple_record`.
+* Set values that `type` can be equal to in `dnsimple_record` resource.
+
+Requirements
+============
+
+A DNSimple account at http://dnsimple.com
+
+Attributes
+==========
+
+All attributes are `nil`, or `false` by default.
+
+- `node[:dnsimple][:username]`: Your DNSimple login username.
+- `node[:dnsimple][:password]`: Your DNSimple login password.
+- `node[:dnsimple][:domain]`: The domain that this node should use.
+- `node[:dnsimple][:test]`: Unused at this time.
+
+Resources/Providers
+===================
+
+dnsimple\_record
+----------------
+
+Manage a DNS resource record through the DNSimple API. This LWRP uses
+the [fog Ruby library](http://rubygems.org/gems/fog) to connect and
+use the API.
+
+### Actions:
+
+    | Action    | Description          | Default |
+    |-----------|----------------------|---------|
+    | *create*  | Create the record.   | Yes     |
+    | *destroy* | Destroy the record.  |         |
+
+### Parameter Attributes:
+
+The type of record can be one of the following: A, CNAME, ALIAS, MX,
+SPF, URL, TXT, NS, SRV, NAPTR, PTR, AAA, SSHFP, or HFINO.
+
+    | Parameter  | Description                | Default |
+    |------------|----------------------------|---------|
+    | *domain*   | Domain to manage           |         |
+    | *name*     | _Name_: Name of the record |         |
+    | *type*     | Type of DNS record         |         |
+    | *content*  | String content of record   |         |
+    | *ttl*      | Time to live.              | 3600    |
+    | *priority* | Priorty of update          |         |
+    | *username* | DNSimple username          |         |
+    | *password* | DNSimple password          |         |
+    | *test*     | Unused at this time        | false   |
+
+### Examples
+
+    dnsimple_record "create an A record" do
+      name     "test"
+      content  "16.8.4.2"
+      type     "A"
+      domain   node[:dnsimple][:domain]
+      username node[:dnsimple][:username]
+      password node[:dnsimple][:password]
+      action   :create
+    end
+
+    dnsimple_record "create a CNAME record for a Google Apps site calendar" do
+      name     "calendar"
+      content  "ghs.google.com"
+      type     "CNAME"
+      domain   node[:dnsimple][:domain]
+      username node[:dnsimple][:username]
+      password node[:dnsimple][:password]
+      action   :create
+    end
+
+Usage
+=====
+
+Add the the `dnsimple` recipe to a node's run list, or with
+`include_recipe` to install the [fog](http://rubygems.org/gems/fog)
+gem, which is used to interact with the DNSimple API. See
+examples of the LWRP usage above.
+
+License and Author
+==================
+
+Author:: Darrin Eden (<darrin@heavywater.ca>)
+Author:: Joshua Timberman (<opensource@housepub.org>)
+
+Copyright:: 2010-2011 Heavy Water Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/attributes/dnsimple.rb
+++ b/attributes/dnsimple.rb
@@ -1,4 +1,21 @@
-default[:dnsimple][:username] = "my_dnsimple_username"
-default[:dnsimple][:password] = "my_dnsimple_password"
-default[:dnsimple][:domain] = "my_default_domain"
-default[:dnsimple][:test] = false
+#
+# Copyright:: Copyright (c) 2010-2011, Heavy Water Software
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default[:dnsimple][:username] = nil # DNSimple username
+default[:dnsimple][:password] = nil # DNSimple password
+default[:dnsimple][:domain] = nil   # Default domain to use
+default[:dnsimple][:fog_version] = "1.1.2" # Default version of fog to install

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,8 +2,8 @@ maintainer       "DNSimple"
 maintainer_email "ops@dnsimple.com"
 license          "Apache 2.0"
 description      "Installs/Configures dnsimple"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.3.2"
 
-recipe   "dnsimple", "Installs DNSimple gem"
+recipe   "dnsimple", "Installs fog gem to use w/ the dnsimple_record"
 supports "ubuntu"

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -1,3 +1,21 @@
+#
+# Copyright:: Copyright (c) 2010-2011, Heavy Water Software
+# Copyright:: Copyright (c) 2012, Joshua Timberman
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 include DNSimple::Connection
 
 action :create do
@@ -10,23 +28,29 @@ action :create do
   zone = dnsimple.zones.get( domain )
 
   zone.records.all.each do |r|
+    Chef::Log.debug "Checking if #{name} exists as #{content} and #{ttl}"
     # do nothing if the record already exists
     break if(( r.name == name ) and
-             ( r.ip == content ) and
+             ( r.value == content ) and
              ( r.ttl == ttl ))
 
     # delete any record with the name we're trying to create
-    r.destroy if r.name == name
+    if r.name == name
+      Chef::Log.debug "Cannot modify a record, must destroy #{name} first"
+      r.destroy
+    end
   end
 
   begin
+    Chef::Log.debug "Attempting to create record type #{type} for #{name} as #{content}"
     record = zone.records.create( :name => name,
-                                  :ip => content,
+                                  :value => content,
                                   :type => type,
                                   :ttl => ttl )
+    new_resource.updated_by_last_action(true)
     Chef::Log.info "DNSimple: created #{type} record for #{name}.#{domain}"
-  rescue Excon::Errors::NotAcceptable
-    # record already exists. moving on.
+  rescue Excon::Errors::UnprocessableEntity
+    Chef::Log.debug "DNSimple: #{name}.#{domain} already exists, moving on"
   end
 end
 
@@ -36,6 +60,7 @@ action :destroy do
   zone.records.all.each do |r|
     if ( r.name == new_resource.name ) and ( r.type == new_resource.type )
       r.destroy
+      new_resource.updated_by_last_action(true)
       Chef::Log.info "DNSimple: destroyed #{new_resource.type} record " +
         "for #{new_resource.name}.#{new_resource.domain}"
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,9 +7,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,11 +17,10 @@
 # limitations under the License.
 #
 
-r = gem_package "fog" do
+gem_package "fog" do
+  version node['dnsimple']['fog_version']
   action :nothing
-  not_if "gem list fog --installed --version '>= 0.7.0'"
-end
-r.run_action( :upgrade )
+end.run_action( :install )
 
 require 'rubygems'
 Gem.clear_paths

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -1,11 +1,33 @@
+#
+# Copyright:: Copyright (c) 2010-2011, Heavy Water Software
+# Copyright:: Copyright (c) 2011, Joshua Timberman
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 actions :create, :destroy
 
 attribute :domain,   :kind_of => String
 attribute :name,     :kind_of => String
-attribute :type,     :kind_of => String
+attribute :type,     :kind_of => String, :equal_to => ["A", "CNAME", "ALIAS", "MX", "SPF", "URL", "TXT", "NS", "SRV", "NAPTR", "PTR", "AAA", "SSHFP", "HFINO"]
 attribute :content,  :kind_of => String
 attribute :ttl,      :kind_of => Integer, :default => 3600
 attribute :priority, :kind_of => Integer
 attribute :username, :kind_of => String
 attribute :password, :kind_of => String
-attribute :test,     :default => false
+
+def initialize(*args)
+  super
+  @action = :create
+end


### PR DESCRIPTION
I did not modify the cookbook version in the metadata, leaving that to you for the next release you make to the Community site.

Thanks for an awesome cookbook, this makes me happy, I hope these updates are useful. :-D
- [all files] - Add license/copyright header comments to the top of files.
- [README] - The Chef Community Site will display READMEs rendered from markdown.
- [LICENSE] - The Cookbook is Apache 2 licensed (via metadata), and should have a LICENSE file designating such
- [attributes] - bail early due to nil attributes that must be set to be usable than to potentially attempt sign in with incorrect credentials
- [attributes] - set the fog gem version as an attribute (the current default value is the version last tested with this cookbook's lwrp
- [provider] - more informative logging in the provider
- [provider] - provider sets new_resource updated by last action so notifications can work
- [provider] - fix Excon exception on zone.records.create rescue
- [resource] - set default action to :create
- [resource] - remove unused attribute :test
- [resource] - type should restrict to actual valid DNS types (upcase!)
