### PR TITLE
Use fog 1.20 instead git revision as mocks are fixed in release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ group :test do
   gem 'kitchen-vagrant'
   gem 'chefspec', '~> 3.0'
   gem 'serverspec'
-  gem 'fog', :git => 'https://github.com/fog/fog'
+  gem 'fog', '~> 1.20'
   gem 'berkshelf'
 end


### PR DESCRIPTION
As latest fog release contains fixed dnsimple mocks, use last gem instead of pinning a git revision.
