### PR TITLE
Use Fog DNSimple API Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ SPF, URL, TXT, NS, SRV, NAPTR, PTR, AAA, SSHFP, or HFINO.
       content  "16.8.4.2"
       type     "A"
       domain   node[:dnsimple][:domain]
-      username node[:dnsimple][:username]
-      password node[:dnsimple][:password]
+      token    node[:dnsimple][:api_token]
       action   :create
     end
 
+    ** USING A PASSWORD IS DEPRECATED **
     dnsimple_record "create a CNAME record for a Google Apps site calendar" do
       name     "calendar"
       content  "ghs.google.com"

--- a/attributes/dnsimple.rb
+++ b/attributes/dnsimple.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-default[:dnsimple][:username] = nil # DNSimple username
-default[:dnsimple][:password] = nil # DNSimple password
-default[:dnsimple][:domain] = nil   # Default domain to use
+default[:dnsimple][:username]  = nil # DNSimple username
+default[:dnsimple][:domain]    = nil # Default domain to use
+default[:dnsimple][:api_token] = nil # DNSimple API Token
+default[:dnsimple][:password]  = nil # DNSimple password (DEPRECATED Set API Token)
+
 default[:dnsimple][:fog_version] = nil # Default version of fog to install

--- a/libraries/dnsimple.rb
+++ b/libraries/dnsimple.rb
@@ -27,9 +27,18 @@ end
 module DNSimple
   module Connection
     def dnsimple
-      @@dnsimple ||= Fog::DNS.new( :provider => "DNSimple",
-                                   :dnsimple_email => new_resource.username,
-                                   :dnsimple_password => new_resource.password )
+      # Warn API Token should be used over password
+      if new_resource.password
+        Chef::Log.warn('[DEPRECATED] Using password for Connection. An API Token will be required in the future.')
+      end
+
+      # Fog will use API Auth instead of password if API Token param is present.
+      @@dnsimple ||= Fog::DNS.new(
+        :provider          => "DNSimple",
+        :dnsimple_email    => new_resource.username,
+        :dnsimple_token    => new_resource.token,
+        :dnsimple_password => new_resource.password
+      )
     end
   end
 end

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -27,6 +27,7 @@ attribute :content,  :kind_of => [String, Array]
 attribute :ttl,      :kind_of => Integer, :default => 3600
 attribute :priority, :kind_of => Integer
 attribute :username, :kind_of => String
-attribute :password, :kind_of => String
+attribute :token,    :kind_of => String
+attribute :password, :kind_of => String # DEPRECATED
 
 attr_accessor :exists


### PR DESCRIPTION
The Fog gem now accepts an API token for creating DNSimple records.
The API Token method is preferred so you can use 2FA auth as well as
not have your password log to console.

The Fog gem currently accepts the token as an additional param. If it
detects the password param it will fall back to username/password auth.

Relates to GH #27 