### PR TITLE
Update build status and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Light-weight Resource and Provider (LWRP) supporting
 automatic DNS configuration via DNSimple's API.
 
-[![Build Status](https://travis-ci.org/aetrion/chef-dnsimple.png?branch=master)](https://travis-ci.org/aetrion/chef-dnsimple)
+[![Build Status](https://travis-ci.org/dnsimple/chef-dnsimple.png?branch=master)](https://travis-ci.org/dnsimple/chef-dnsimple)
 
 ## Requirements
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'Apache 2.0'
 description      'Provides Chef LWRP for automating DNS configuration with DNSimple'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.1.0'
+issues_url       'https://github.com/dnsimple/chef-dnsimple/issues'
+source_url       'https://github.com/dnsimple/chef-dnsimple'
 
 recipe   'dnsimple', 'Installs fog gem to use w/ the dnsimple_record'
 


### PR DESCRIPTION
We have moved the repository over to the new dnsimple organization on github so this pull request updates the relevant metadata and README entries. There is an automatic redirect in place, but we're migrating everything now versus later.