### PR TITLE
Revise the token usage documentation

### DIFF
--- a/libraries/dnsimple.rb
+++ b/libraries/dnsimple.rb
@@ -33,6 +33,7 @@ module DNSimple
       end
 
       @@dnsimple ||= Fog::DNS.new( :provider => "DNSimple",
+                                   :dnsimple_domain => new_resource.domain,
                                    :dnsimple_email => new_resource.username,
                                    :dnsimple_password => new_resource.password,
                                    :dnsimple_token => new_resource.token )


### PR DESCRIPTION
We noted this in the README, but it turns out in order to get Fog to force the usage of domain tokens, the library must be initialized with the domain provided with the connection information. In order to avoid a breaking change, we are updating the documentation to reflect the current and proper usage. Domain based tokens will be supported in a future release. Just not this one.