### PR TITLE
Update documentation with a correction for the token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ SPF, URL, TXT, NS, SRV, NAPTR, PTR, AAA, SSHFP, or HFINO.
     | *test*       | Unused at this time                | false     |
 
 **Note**: For token based authentication you must provide an [api token][] for
-the account with access to the domain you are providing in the resource.
-Domain based tokens will be supported in a future release.
+the account with access to the domain you are providing in the resource. User
+access tokens are also not supported at this time.  Domain based tokens will be
+supported in a future release.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ SPF, URL, TXT, NS, SRV, NAPTR, PTR, AAA, SSHFP, or HFINO.
     | *token*      | DNSimple API token                 |           |
     | *test*       | Unused at this time                | false     |
 
-**Note**: For token based authentication you must provide a [domain token][]
-for the domain you are providing in the resource. Account tokens will be
-supported in a future release.
+**Note**: For token based authentication you must provide an [api token][] for
+the account with access to the domain you are providing in the resource.
+Domain based tokens will be supported in a future release.
 
 ### Examples
 
@@ -138,4 +138,4 @@ limitations under the License.
 [VirtualBox]: https://www.virtualbox.org/wiki/Downloads
 [Vagrant]: https://www.vagrantup.com/downloads.html
 [Chefstyle]: https://github.com/chef/chefstyle
-[domain token]: https://developer.dnsimple.com/v1/authentication/#domain-token
+[api token]: https://developer.dnsimple.com/v1/authentication/#api-token


### PR DESCRIPTION
We noted this in the README, but it turns out in order to get Fog to force the usage of domain tokens, the library must be initialized with the domain provided with the connection information. In order to avoid a breaking change, we are updating the documentation to reflect the current and proper usage. Domain based tokens will be supported in a future release. Just not this one.