### PR TITLE
Update Travis-CI builds to use Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,11 @@ install: echo "skip bundle install"
 
 before_script:
 - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-- chef gem install test-kitchen
 - chef gem install kitchen-docker
 - chef gem install chefstyle
 - chef gem install stove
 
-script: chef exec rake quick
+script: chef exec rake
 
 notifications:
   slack:


### PR DESCRIPTION
I've removed the gem install of test kitchen since the new ChefDK includes the bugfix to environment vars via Rake. This also runs the full chef11/chef12 suites via `rake` which gives us ChefSpec and ServerSpec coverage.