### PR TITLE
Force apt in the run list for ubuntu platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,10 +7,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+    run_list: apt::default
   - name: ubuntu-12.04
-    attributes:
-      apt:
-        compile_time_update: true
+    run_list: apt::default
   - name: centos-6.7
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,14 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
     run_list: apt::default
+    attributes:
+      apt:
+        compile_time_update: true
   - name: ubuntu-12.04
     run_list: apt::default
+    attributes:
+      apt:
+        compile_time_update: true
   - name: centos-6.7
 
 suites:


### PR DESCRIPTION
We're hitting weird compile time issues so this should force apt to update and sync immediately in testing.
