### PR TITLE
Swap fog gem for fog-dnsimple

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,4 +34,4 @@ chef_gem 'fog-dnsimple' do
   action :install
 end
 
-require 'fog'
+require 'fog/dnsimple'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ end
 
 include_recipe 'build-essential'
 
-chef_gem 'fog' do
+chef_gem 'fog-dnsimple' do
   version node['dnsimple']['fog_version']
   compile_time true if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
   action :install

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -4,7 +4,7 @@ describe 'dnsimple::default' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it 'installs fog chef_gem' do
-    expect(chef_run).to install_chef_gem 'fog'
+    expect(chef_run).to install_chef_gem 'fog-dnsimple'
   end
 
   context 'when on the debian platform family' do

--- a/test/integration/chef11/serverspec/dnsimple_spec.rb
+++ b/test/integration/chef11/serverspec/dnsimple_spec.rb
@@ -1,9 +1,14 @@
 require 'spec_helper'
 
-describe package('zlib1g-dev'), if: os[:family] == 'debian' do
-  it { should be_installed }
+describe 'dnsimple fog gem dependencies', if: ['debian', 'ubuntu'].include?(os[:family]) do
+  it 'must be present' do
+    expect(package('zlib1g-dev')).to be_installed
+  end
 end
 
-describe file('/opt/chef/embedded/bin/fog') do
-  it { should be_file }
+describe 'dnsimple fog gem' do
+  it 'must be installed in the embedded chef rubygems' do
+    expect(command('/opt/chef/embedded/bin/gem list | grep dnsimple').stdout).to \
+      match(/^fog-dnsimple/)
+  end
 end

--- a/test/integration/chef11/serverspec/dnsimple_spec.rb
+++ b/test/integration/chef11/serverspec/dnsimple_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'dnsimple fog gem dependencies', if: ['debian', 'ubuntu'].include?(os[:family]) do
+describe 'dnsimple fog gem dependencies', if: %w(debian ubuntu).include?(os[:family]) do
   it 'must be present' do
     expect(package('zlib1g-dev')).to be_installed
   end

--- a/test/integration/chef12/serverspec/dnsimple_spec.rb
+++ b/test/integration/chef12/serverspec/dnsimple_spec.rb
@@ -1,9 +1,14 @@
 require 'spec_helper'
 
-describe package('zlib1g-dev'), if: os[:family] == 'debian' do
-  it { should be_installed }
+describe 'dnsimple fog gem dependencies', if: ['debian', 'ubuntu'].include?(os[:family]) do
+  it 'must be present' do
+    expect(package('zlib1g-dev')).to be_installed
+  end
 end
 
-describe file('/opt/chef/embedded/bin/fog') do
-  it { should be_file }
+describe 'dnsimple fog gem' do
+  it 'must be installed in the embedded chef rubygems' do
+    expect(command('/opt/chef/embedded/bin/gem list | grep dnsimple').stdout).to \
+      match(/^fog-dnsimple/)
+  end
 end

--- a/test/integration/chef12/serverspec/dnsimple_spec.rb
+++ b/test/integration/chef12/serverspec/dnsimple_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'dnsimple fog gem dependencies', if: ['debian', 'ubuntu'].include?(os[:family]) do
+describe 'dnsimple fog gem dependencies', if: %w(debian ubuntu).include?(os[:family]) do
   it 'must be present' do
     expect(package('zlib1g-dev')).to be_installed
   end


### PR DESCRIPTION
To simplify and slim-down the fog gem, the DNSimple provider was extracted by @weppos into fog-dnsimple. So this is a fairly straightforward swap out since the API is the same as before. We'll eventually use the newer v2 API DNSimple gem, but as of today it is breaking for users of this cookbook since the fog gem no longer includes DNSimple as a default module.