### PR TITLE
It seems that Chef 11 and Compat resources no go

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,10 +20,3 @@ suites:
     run_list:
       - recipe[dnsimple::default]
     attributes:
-
-  - name: chef11
-    provisioner:
-      require_chef_omnibus: '11.18.12'
-    run_list:
-      - recipe[dnsimple::default]
-    attributes:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ automatic DNS configuration via DNSimple's API.
 ## Requirements
 
 * A DNSimple account at https://dnsimple.com
-* Chef 11 or newer
+* Chef 12 or newer
 
 ## Deprecation Warning
 


### PR DESCRIPTION
```
RuntimeError
------------
This resource is written with Chef 12.5 custom resources, and
requires at least Chef 12.0 used with the compat_resource
cookbook, it will not work with Chef 11.x clients, and those
users must pin their cookbooks to older versions or upgrade.
```

It might be time to put 11 to bed, and focus on 12 :-/

https://jenkins-01.eastus.cloudapp.azure.com/job/dnsimple-cookbook/158/console

Signed-off-by: JJ Asghar <jj@chef.io>