### PR TITLE
Use latest versions of images for testing

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -13,4 +13,3 @@ platforms:
 - name: ubuntu-16.04
 - name: centos-6
 - name: centos-7
-- name: freebsd-11

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -11,5 +11,6 @@ verifier:
 platforms:
 - name: ubuntu-14.04
 - name: ubuntu-16.04
-- name: centos-6.8
-- name: centos-7.3
+- name: centos-6
+- name: centos-7
+- name: freebsd-11

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,9 +16,9 @@ verifier:
 platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-  - name: centos-6.8
-  - name: centos-7.3
-  - name: freebsd-11.0
+  - name: centos-6
+  - name: centos-7
+  - name: freebsd-11
 
 suites:
   - name: create_record


### PR DESCRIPTION
This short PR updates all the references to the bento boxes which come from [examples](https://github.com/chef-cookbooks/testing_examples) that now use meta bento boxes which always reference the latest releases of CentOS and FreeBSD.