### PR TITLE
Add all_certificates endpoint and fix certificates spec

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,8 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 13
+  product_name: chef
+  product_version: 13
   always_update_cookbooks: <%= !ENV['CI'] %>
 
 verifier:

--- a/libraries/provider_dnsimple_certificate.rb
+++ b/libraries/provider_dnsimple_certificate.rb
@@ -30,9 +30,7 @@ class Chef
         @current_resource.certificate_common_name(@new_resource.certificate_common_name)
         @current_resource.domain(@new_resource.domain)
 
-        # TODO: replace dnsimple_client.certificates.certificates with .all_certificates when it is added
-        # to the API client
-        certificates = dnsimple_client.certificates.certificates(dnsimple_client_account_id, @new_resource.domain)
+        certificates = dnsimple_client.certificates.all_certificates(dnsimple_client_account_id, @new_resource.domain)
         @existing_certificate = certificates.data.detect do |certificate|
           (certificate.common_name == @new_resource.certificate_common_name) && (certificate.state == 'issued') && (Date.parse(certificate.expires_on) > Date.today)
         end

--- a/spec/libraries/provider_dnsimple_certificate_spec.rb
+++ b/spec/libraries/provider_dnsimple_certificate_spec.rb
@@ -4,7 +4,6 @@ require 'date'
 require_relative '../../libraries/provider_dnsimple_certificate'
 require_relative '../../libraries/resource_dnsimple_certificate'
 
-
 describe Chef::Provider::DnsimpleCertificate do
   before(:each) do
     @node = stub_node(platform: 'ubuntu', version: '14.04')

--- a/spec/libraries/provider_dnsimple_certificate_spec.rb
+++ b/spec/libraries/provider_dnsimple_certificate_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 require 'dnsimple'
+require 'date'
 require_relative '../../libraries/provider_dnsimple_certificate'
 require_relative '../../libraries/resource_dnsimple_certificate'
+
 
 describe Chef::Provider::DnsimpleCertificate do
   before(:each) do
@@ -38,9 +40,10 @@ describe Chef::Provider::DnsimpleCertificate do
       {
         id: 1,
         common_name: 'www.example.com',
-        expires_on: '2018-01-01',
+        expires_on: next_year,
       }
     end
+    let(:next_year) { Date.today.next_day(365).strftime('%F') }
 
     context 'if the certificate exists' do
       it 'installs the certificate' do

--- a/spec/libraries/provider_dnsimple_certificate_spec.rb
+++ b/spec/libraries/provider_dnsimple_certificate_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Provider::DnsimpleCertificate do
     let(:whoami_response) { instance_double(Dnsimple::Response, data: data) }
     let(:data) { instance_double(Dnsimple::Struct::Whoami, account: account) }
     let(:account) { instance_double(Dnsimple::Struct::Account, id: 1) }
-    let(:certificates) { instance_double(Dnsimple::Client::Certificates, certificates: certificate_list, download_certificate: certificate_bundle_response, certificate_private_key: private_key_bundle_response) }
+    let(:certificates) { instance_double(Dnsimple::Client::Certificates, all_certificates: certificate_list, download_certificate: certificate_bundle_response, certificate_private_key: private_key_bundle_response) }
     let(:certificate_list) { instance_double(Dnsimple::CollectionResponse, data: [certificate]) }
     let(:certificate) { instance_double(Dnsimple::Struct::Certificate, id: certificate_data[:id], common_name: certificate_data[:common_name], expires_on: certificate_data[:expires_on], state: 'issued') }
     let(:certificate_bundle_response) { instance_double(Dnsimple::Response, data: certificate_bundle) }


### PR DESCRIPTION
This PR fixes two things:

* Implements the `all_certificates` endpoint we added via https://github.com/dnsimple/dnsimple-ruby/pull/155 and updates the specs
* Fixes a really silly date bug in our certificate spec