### PR TITLE
Bugfix: AAAA record validation in dnsimple_record resource

### DIFF
--- a/libraries/resource_dnsimple_record.rb
+++ b/libraries/resource_dnsimple_record.rb
@@ -29,7 +29,7 @@ class Chef
       property :record_name,   kind_of: String, name_property: true
       property :domain,        kind_of: String
       property :name,          kind_of: String, required: true
-      property :type,          kind_of: String, equal_to: %w(A CNAME ALIAS MX SPF URL TXT NS SRV NAPTR PTR AAA SSHFP HFINO), required: true
+      property :type,          kind_of: String, equal_to: %w(A CNAME ALIAS MX SPF URL TXT NS SRV NAPTR PTR AAAA SSHFP HFINO), required: true
       property :content,       kind_of: [String, Array]
       property :ttl,           kind_of: Integer, default: 3600
       property :priority,      kind_of: Integer

--- a/spec/libraries/provider_dnsimple_record_spec.rb
+++ b/spec/libraries/provider_dnsimple_record_spec.rb
@@ -51,7 +51,15 @@ describe Chef::Provider::DnsimpleRecord do
       expect { @provider.load_current_resource }.to_not raise_exception
     end
 
-    context 'when it fails validation' do
+    context 'when it fails type validation' do
+      it 'raises an exception' do
+        expect { @new_resource.type = 'AA' }.to \
+          raise_exception(Chef::Exceptions::ValidationFailed,
+                          'Option type must be equal to one of: A, CNAME, ALIAS, MX, SPF, URL, TXT, NS, SRV, NAPTR, PTR, AAAA, SSHFP, HFINO!  You passed "AA".')
+      end
+    end
+
+    context 'when it fails request validation' do
       before do
         allow(zones).to receive(:create_record)
           .and_raise(Dnsimple::RequestError, request_error)


### PR DESCRIPTION
Found a bug in the validation for the AAAA option in the dnsimple_record resource where we missed a letter in the record type. 