### PR TITLE
Bugfix: Correctly validate the test domain in Inspec

### DIFF
--- a/test/integration/update_record/controls/update_record.rb
+++ b/test/integration/update_record/controls/update_record.rb
@@ -1,6 +1,6 @@
 token = attribute('dnsimple_token', description: 'The dnsimple API token')
 test_domain = attribute('test_domain', description: 'The domain to test against the API')
 describe dnsimple_zone(test_domain, name: 'cnamerecord', token: token, type: 'CNAME') do
-  its('content') { should eq 'testing.dnsimple.xyz' }
+  its('content') { should eq "testing.#{test_domain}" }
   its('ttl') { should eq 60 }
 end


### PR DESCRIPTION
This fixes #52 by pushing the inspec parameter down to the validation in the inspec test.