### PR TITLE
CircleCI Trial using pure Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2.1
+
+jobs:
+  delivery:
+    docker:
+      - image: chef/chefdk:3
+    steps:
+      - checkout
+      - run:
+          name: Add dnsimple gem
+          command: chef gem install dnsimple
+      - run: delivery local all
+  dokken:
+    docker:
+      - image: chef/chefdk:3
+    parameters:
+      suite:
+        description: Test kitchen suite name
+        type: string
+    environment:
+      KITCHEN_LOCAL_YAML: .kitchen.dokken.yml
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Add dnsimple gem
+          command: chef gem install dnsimple
+      - run:
+          name: centos-6
+          command: kitchen test <<parameters.suite>>-centos-6
+          environment:
+            DNSIMPLE_TEST_DOMAIN: <<parameters.suite>>-centos-6-dnsimple.xyz
+      - run:
+          name: centos-7
+          command: kitchen test <<parameters.suite>>-centos-7
+          environment:
+            DNSIMPLE_TEST_DOMAIN: <<parameters.suite>>-centos-7-dnsimple.xyz
+      - run:
+          name: ubuntu-1404
+          command: kitchen test <<parameters.suite>>-ubuntu-1404
+          environment:
+            DNSIMPLE_TEST_DOMAIN: <<parameters.suite>>-ubuntu-1404-dnsimple.xyz
+      - run:
+          name: ubuntu-1604
+          command: kitchen test <<parameters.suite>>-ubuntu-1604
+          environment:
+            DNSIMPLE_TEST_DOMAIN: <<parameters.suite>>-ubuntu-1604-dnsimple.xyz
+      - run:
+          name: ubuntu-1804
+          command: kitchen test <<parameters.suite>>-ubuntu-1804
+          environment:
+            DNSIMPLE_TEST_DOMAIN: <<parameters.suite>>-ubuntu-1804-dnsimple.xyz
+
+workflows:
+  test_kitchen:
+    jobs:
+      - delivery
+      - dokken:
+          name: create-record
+          suite: create-record
+          requires:
+            - delivery
+      - dokken:
+          name: update-record
+          suite: update-record
+          requires:
+            - delivery

--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"


### PR DESCRIPTION
This is mainly setup to demonstrate a failure case that should otherwise work since Dokken is based on Docker, but it requires access to mount volumes within the container in order to work. If it works, it will be significantly faster than just a machine image.