### PR TITLE
CentOS 6 EOL, add CentOS 8 to actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'centos-6'
           - 'centos-7'
+          - 'centos-8'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
         suite:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -33,11 +33,6 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: centos-6
-    driver:
-      image: dokken/centos-6
-      pid_one_command: /sbin/init
-
   - name: centos-7
     driver:
       image: dokken/centos-7


### PR DESCRIPTION
- Removes CentOS 6 configuration from `kitchen.yml` due to EOL
- Adds CentOS 8 configuration to GitHub Actions CI

### Verification

- [x] Ensure CI test suite does not include CentOS 6
- [x] Ensure CI tests pass in CentOS 8