### PR TITLE
kitchen chef-client v18

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -2,7 +2,7 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: 16
+  chef_version: 18
 
 transport:
   name: dokken


### PR DESCRIPTION
**Has a resource with unified mode disabled**

Bump `kitchen.yml` chef-client version to 18

Belongs to https://github.com/dnsimple/dnsimple-ops/issues/3084

## :shipit: Deploy Steps:

- [x] Merge

## :shipit: Verification Steps

- [ ] Ensure ALL tests pass without errors