### PR TITLE
update workflow jobs, add dependabot for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - task
+      - dependencies
+    reviewers:
+      - "dnsimple/sip"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
+      - name: Install DNSimple gem
+        run: chef gem install -N dnsimple -v '~> 7'
+        env:
+          CHEF_LICENSE: accept-no-persist
       - name: Rspec
         run: chef exec rake spec
         env:
@@ -79,6 +83,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
+      - name: Install DNSimple gem
+        run: chef gem install -N dnsimple -v '~> 7'
+        env:
+          CHEF_LICENSE: accept-no-persist
       - name: Run Test Kitchen
         uses: actionshub/test-kitchen@main
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,12 @@ jobs:
           DNSIMPLE_TEST_DOMAIN: ${{ matrix.suite }}-record-${{ matrix.os }}-dnsimple.xyz
           KITCHEN_LOCAL_YAML: kitchen.yml
         with:
-          suite: ${{ matrix.suite }}
+          suite: ${{ matrix.suite }}-record
           os: ${{ matrix.os }}
       - name: Debug
         if: failure()
         run: |
             set -x
             sudo journalctl -l --since today
-            KITCHEN_LOCAL_YAML=kitchen.yml /usr/bin/kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"
+            KITCHEN_LOCAL_YAML=kitchen.yml DNSIMPLE_TEST_DOMAIN=${{ matrix.suite }}-record-${{ matrix.os }}-dnsimple.xyz /usr/bin/kitchen exec \
+            ${{ matrix.suite }}-record-${{ matrix.os }} -c "journalctl -l"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,27 @@
 ---
 name: ci
 
-"on":
+on:
   pull_request:
   push:
     branches:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  delivery:
+  cookstyle:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
-      - name: Install DNSimple gem
-        run: chef gem install -N dnsimple -v '~> 7'
-        env:
-          CHEF_LICENSE: accept-no-persist
       - name: Run Cookstyle
         run: chef exec rake cookstyle
-        env:
-          CHEF_LICENSE: accept-no-persist
-      - name: Run Specs
-        run: chef exec rake spec
         env:
           CHEF_LICENSE: accept-no-persist
 
@@ -33,23 +29,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v2.0.0
+        uses: nosborn/github-action-markdown-cli@v3.2.0
         with:
           files: .
           config_file: ".markdownlint.yaml"
+
+  rspec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Install Chef Workstation
+        uses: actionshub/chef-install@main
+      - name: Rspec
+        run: chef exec rake spec
+        env:
+          CHEF_LICENSE: accept-no-persist
 
   yamllint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run YAML Lint
         uses: actionshub/yamllint@main
 
   integration:
-    needs: [delivery, markdownlint-cli, yamllint]
+    needs:
+      - cookstyle
+      - markdownlint-cli
+      - rspec
+      - yamllint
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -64,27 +76,22 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
-      - name: Install DNSimple gem
-        run: chef gem install -N dnsimple -v '~> 7'
-        env:
-          CHEF_LICENSE: accept-no-persist
       - name: Run Test Kitchen
         uses: actionshub/test-kitchen@main
         env:
           CHEF_LICENSE: accept-no-persist
-          KITCHEN_LOCAL_YAML: kitchen.yml
           DNSIMPLE_ACCESS_TOKEN: ${{ secrets.DNSIMPLE_ACCESS_TOKEN }}
           DNSIMPLE_TEST_DOMAIN: ${{ matrix.suite }}-record-${{ matrix.os }}-dnsimple.xyz
+          KITCHEN_LOCAL_YAML: kitchen.yml
         with:
-          suite: ${{ matrix.suite }}-record
+          suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
       - name: Debug
         if: failure()
         run: |
             set -x
             sudo journalctl -l --since today
-            KITCHEN_LOCAL_YAML=kitchen.yml DNSIMPLE_TEST_DOMAIN=${{ matrix.suite }}-record-${{ matrix.os }}-dnsimple.xyz /usr/bin/kitchen exec \
-            ${{ matrix.suite }}-record-${{ matrix.os }} -c "journalctl -l"
+            KITCHEN_LOCAL_YAML=kitchen.yml /usr/bin/kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"

--- a/.yamllint
+++ b/.yamllint
@@ -5,3 +5,6 @@ rules:
   line-length:
     max: 256
     level: warning
+  truthy:
+    ignore: |
+      /.github/workflows/*.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If your issue is in regards to security, please refer to our [security page](htt
 In order to maintain a high standard of compatibility and consistency for the consumers of our cookbook we like to make sure all pull requests meet the following criteria:
 
 1. **Tests:** To ensure high quality code and protect against regressions in the future we require all changes have ample test coverage. This does not mean 100% coverage or even specific types of coverage. See the TESTING.md file for details on how to run the test suite.
-2. **Passing Continuous Integration (CI):** Speaking of tests, the contributed code must pass our full suite of tests on [Travis-CI][] and show a green indicator meaning the latest build passes. If for some reason the build is failing before your pull request please raise the issue in the pull request so we may address it.
+2. **Passing Continuous Integration (CI):** Speaking of tests, the contributed code must pass our full suite of tests on [GitHub](https://github.com/dnsimple/chef-dnsimple/actions) and show a green indicator meaning the latest build passes. If for some reason the build is failing before your pull request please raise the issue in the pull request so we may address it.
 
 ### Code Review Process
 
@@ -42,5 +42,4 @@ Once you open a pull request, cookbook maintainers will review your code using t
 * **DONT** modify the CHANGELOG.md in your pull request as well. The maintainers will auto-generate this before a new release.
 * **DO** remember that humans are handling your contributions so please be nice and polite when discussing anything in your pull request.
 
-[security page]: https://dnsimple.com/security
-[Travis-CI]: https://travis-ci.com
+[DNSimple Security Page](https://dnsimple.com/security)


### PR DESCRIPTION
- Updates `ci.yml` jobs to replace 'delivery' with 'cookstyle' and 'rspec'
- Bump GH actions dependencies
- Ignore truthy in `ci.yml` for GH actions configuration