### PR TITLE
Patch/dependencies update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'centos-7'
           - 'centos-8'
-          - 'ubuntu-1804'
+          - 'rockylinux-8'
+          - 'rockylinux-9'
           - 'ubuntu-2004'
+          - 'ubuntu-2204'
         suite:
           - 'create'
           - 'update'
@@ -84,7 +85,7 @@ jobs:
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
       - name: Install DNSimple gem
-        run: chef gem install -N dnsimple -v '~> 7'
+        run: chef gem install -N dnsimple -v '~> 8'
         env:
           CHEF_LICENSE: accept-no-persist
       - name: Run Test Kitchen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
       - name: Install DNSimple gem
-        run: chef gem install -N dnsimple -v '~> 7'
+        run: chef gem install -N dnsimple -v '~> 8'
         env:
           CHEF_LICENSE: accept-no-persist
       - name: Rspec

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you used the dnsimple_certificate resource, you'll want to do the following t
 
 * A [dnsimple](https://dnsimple.com/) account
 * An [account access token](https://developer.dnsimple.com/v2/#account-tokens-vs-user-tokens) from said dnsimple account
-* Chef 15 or newer
+* Chef Client 17 or newer
 
 ## Attributes
 
@@ -177,6 +177,6 @@ See CONTRIBUTING.md
 
 ## License
 
-Copyright 2021, DNSimple Corp.
+Copyright 2023, DNSimple Corp.
 
 Licensed under the Apache License, Version 2.0.

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,13 +19,6 @@ verifier:
     test_domain: <%= ENV['DNSIMPLE_TEST_DOMAIN'] || 'dnsimple.xyz' %>
 
 platforms:
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
@@ -33,14 +26,26 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: centos-7
+  - name: ubuntu-22.04
     driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
+      image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
 
   - name: centos-8
     driver:
       image: dokken/centos-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-9
+    driver:
+      image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
 suites:

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,9 +7,9 @@ issues_url       'https://github.com/dnsimple/chef-dnsimple/issues'
 source_url       'https://github.com/dnsimple/chef-dnsimple'
 version          '4.0.0'
 
-chef_version '>= 15'
+chef_version '>= 17'
 
-gem 'dnsimple', '~> 7'
+gem 'dnsimple', '~> 8'
 
 %w(amazon centos debian fedora freebsd redhat ubuntu).each do |os|
   supports os


### PR DESCRIPTION
- Update dnsimple gem version to ~8
- Replace ubuntu-1804 with ubuntu-2204
- Add rockylinux-(8/9) to test suite
- Remove centos-7

Closes https://github.com/dnsimple/chef-dnsimple/issues/81

Tasks
- [ ] Release major to chef supermarket