### PR TITLE
Switch dnsimple gem installation from gem_package to chef_gem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@ build_essential 'install tools' do
   compile_time true
 end
 
-gem_package 'dnsimple' do
+chef_gem 'dnsimple' do
   version '~> 9'
   action :upgrade
 end


### PR DESCRIPTION
As per https://docs.chef.io/resources/chef_gem/

The chef_gem and gem_package resources are both used to install Ruby gems. For any machine on which Chef Infra Client is installed, there are two instances of Ruby. One is the standard, system-wide instance of Ruby and the other is a dedicated instance that is available only to Chef Infra Client. Use the chef_gem resource to install gems into the instance of Ruby that is dedicated to Chef Infra Client. Use the gem_package resource to install all other gems (i.e. install gems system-wide).