### PR TITLE
Adds support for centos-stream 9 & 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'centos-8'
+          - 'centos-stream-9'
+          - 'centos-stream-10'
           - 'rockylinux-8'
           - 'rockylinux-9'
           - 'ubuntu-2004'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -40,9 +40,14 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: centos-8
+  - name: centos-stream-9
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-9
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: centos-stream-10
+    driver:
+      image: dokken/centos-stream-10
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: rockylinux-8


### PR DESCRIPTION
Updates the supported platforms to remove EoL items and add current stable releases for CentOS

- Remove CentOS 8 from supported platforms
- Add CentOS Stream 9 & 10 to supported platforms